### PR TITLE
:sheep:  添加缺失注解

### DIFF
--- a/spring-cloud-config-git/spring-cloud-config-client/src/main/java/com/neo/ConfigClientApplication.java
+++ b/spring-cloud-config-git/spring-cloud-config-client/src/main/java/com/neo/ConfigClientApplication.java
@@ -5,12 +5,11 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 
-
 @SpringBootApplication
 @EnableConfigurationProperties
-public class ClientApplication {
+public class ConfigClientApplication {
 
-    public static void main(String[] args) {
-        SpringApplication.run(ClientApplication.class, args);
-    }
+	public static void main(String[] args) {
+		SpringApplication.run(ConfigClientApplication.class, args);
+	}
 }

--- a/spring-cloud-config-git/spring-cloud-config-client/src/main/java/com/neo/ConfigClientApplication.java
+++ b/spring-cloud-config-git/spring-cloud-config-client/src/main/java/com/neo/ConfigClientApplication.java
@@ -3,11 +3,14 @@ package com.neo;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+
 
 @SpringBootApplication
-public class ConfigClientApplication {
+@EnableConfigurationProperties
+public class ClientApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(ConfigClientApplication.class, args);
-	}
+    public static void main(String[] args) {
+        SpringApplication.run(ClientApplication.class, args);
+    }
 }


### PR DESCRIPTION
根据  http://www.ityouknow.com/springcloud/2017/05/22/springcloud-config-git.html  文档，在 client 端配置启动项时，使用 @EnableConfigServer 注解，但是相应jar包也 Maven 并未引用，经过尝试，此处使用 @EnableConfigurationProperties 可以了，虽然不懂为什么